### PR TITLE
Fix KtlintErrorHandler to be compatible with IDEA 203.*

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@
 
 pluginGroup = com.nbadal
 pluginName_ = ktlint
-pluginVersion = 0.5.1
+pluginVersion = 0.5.2
 pluginSinceBuild = 193
-pluginUntilBuild = 202.*
+pluginUntilBuild = 203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3


### PR DESCRIPTION
JetBrains released [IntelliJ IDEA 203](https://www.jetbrains.com/idea/whatsnew/#whats-new-20203) on December 1st. Because the version requirement specified in `gradle.properties` is `202.*`, this plugin does not run after updating. This was reported in #16.

We should be able to change just the version requirement. The only potential incompatibility mentioned that likely affects `com.nbadal.ktlint.KtlintErrorHandler`. This can be found in the official documentation under **Incompatible Changes in IntelliJ Platform and Plugins API 2020.** > **2020.3** > [Changes in IntelliJ Platform 2020.3](https://jetbrains.org/intellij/sdk/docs/reference_guide/api_changes/api_changes_list_2020.html#changes-in-intellij-platform-20203). The specific part is this:

> **`com.intellij.openapi.diagnostic.ErrorReportSubmitter.submit` method parameter type changed from `Consumer<SubmittedReportInfo>` to `Consumer<? super SubmittedReportInfo>`**
    This may break source-compatibility with inheritors written in Kotlin.

In the case of this plugin, the change should be transparent. None of the other changes listed in the incompatible changes list, nor in the [Notable Changes](https://jetbrains.org/intellij/sdk/docs/reference_guide/api_notable/api_notable_list_2020.html#notable-changes-in-intellij-platform-20203) list seem to apply.

To fix the issue, **the changes in this PR are**:

* Bumps the version requirement from `202.*` to `203.*`
* Bumps the plugin version from `0.5.1` to `0.5.2`

There do not appear to be any contribution guidelines, so if the plugin version needs to be bumped in a separate commit, that can be changed.

~It is not possible (as far as I'm aware) to test the plugin as-is, since the `secrets.properties` is a hard-requirement that is not available to third-parties. After removing the code relying on `secrets.properties` (and a few other small, related tweaks), the plugin does work, but this does technically invalidate tests.~

It looks like tests did run, and pass, after opening this PR, although I can not build locally due to the missing `secrets.properties`.