### PR TITLE
Bump IntelliJ version from 203.* to 211.*

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@
 
 pluginGroup = com.nbadal
 pluginName_ = ktlint
-pluginVersion = 0.7.3
+pluginVersion = 0.7.4
 pluginSinceBuild = 193
-pluginUntilBuild = 203.*
+pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.4, 2020.3.2
+pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.4, 2020.3.2, 2021.1
 
 platformType = IC
 platformVersion = 2019.3


### PR DESCRIPTION
JetBrains released [IntelliJ IDEA 2020.1](https://blog.jetbrains.com/kotlin/2021/04/kotlin-plugin-2021-1-released) on April 6th. Because the version requirement specified in `gradle.properties` is `203.*`, this plugin does not run after updating. This was reported in #36.

### Changes

This PR:
* Bumps the plugin version from `0.7.3` to `0.7.4`
* Bumps the version requirement from `203.*` to `211.*`
* Adds `2021.1` to the `pluginVerifierIdeVersions` list.

### Checks
* The release notes do not show any relevant [breaking changes](https://plugins.jetbrains.com/docs/intellij/api-changes-list.html).
* `./gradlew verifyPlugin` succeeds.
* `./gradlew runPluginVerifier` succeeds.
* `./gradlew buildPlugin` succeeds.
* `./gradlew test` succeeds.
* CI tests could not be run

This change should be similar to #17, but I missed `pluginVerifierIdeVersions` last time.