### PR TITLE
Add Ktlint reformatting as an IntelliJ on save action

### DIFF
--- a/plugin/src/main/java/KtlintConfigForm.form
+++ b/plugin/src/main/java/KtlintConfigForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="KtlintConfigForm">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="12" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="680" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <component id="27d8a" class="javax.swing.JLabel">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="strings" key="disabledRulesLabel"/>
@@ -38,7 +38,7 @@
       </component>
       <component id="36cbd" class="javax.swing.JLabel">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="strings" key="editorconfigLabel"/>
@@ -46,7 +46,7 @@
       </component>
       <component id="f7c2c" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="editorConfigPath">
         <constraints>
-          <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -54,7 +54,7 @@
       </component>
       <vspacer id="f22cd">
         <constraints>
-          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="3e9db" class="javax.swing.JCheckBox" binding="androidMode">
@@ -69,7 +69,7 @@
       </component>
       <component id="909eb" class="javax.swing.JLabel">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="strings" key="rulesetLabel"/>
@@ -77,7 +77,7 @@
       </component>
       <component id="c98b6" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="externalJarPaths">
         <constraints>
-          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -85,7 +85,7 @@
       </component>
       <component id="15acd" class="javax.swing.JButton" binding="githubButton">
         <constraints>
-          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="strings" key="githubButton"/>
@@ -94,7 +94,7 @@
       <grid id="e0fa6" binding="disabledRulesContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -113,7 +113,7 @@
       </component>
       <component id="6990b" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="baselinePath">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -121,7 +121,7 @@
       </component>
       <component id="2e3b0" class="javax.swing.JLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="strings" key="baselineLabel"/>
@@ -139,6 +139,15 @@
         </constraints>
         <properties>
           <text resource-bundle="strings" key="annotateAsLabel"/>
+        </properties>
+      </component>
+      <component id="c4194" class="javax.swing.JCheckBox" binding="formatOnSave">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="strings" key="formatOnSaveText"/>
+          <toolTipText resource-bundle="strings" key="formatOnSaveTooltip"/>
         </properties>
       </component>
     </children>

--- a/plugin/src/main/java/KtlintConfigForm.kt
+++ b/plugin/src/main/java/KtlintConfigForm.kt
@@ -23,11 +23,14 @@ import javax.swing.JPanel
 class KtlintConfigForm(private val project: Project, private val config: KtlintConfigStorage) {
 
     private lateinit var mainPanel: JPanel
-    private lateinit var enableKtlint: JCheckBox
+    lateinit var enableKtlint: JCheckBox
+        private set
     private lateinit var androidMode: JCheckBox
     private lateinit var enableExperimental: JCheckBox
     private lateinit var annotateAs: JComboBox<AnnotationMode>
     private lateinit var lintAfterReformat: JCheckBox
+    lateinit var formatOnSave: JCheckBox
+        private set
     private lateinit var disabledRulesContainer: JPanel
     private lateinit var externalJarPaths: TextFieldWithBrowseButton
     private lateinit var baselinePath: TextFieldWithBrowseButton
@@ -87,6 +90,7 @@ class KtlintConfigForm(private val project: Project, private val config: KtlintC
             androidMode,
             annotateAs,
             lintAfterReformat,
+            formatOnSave,
             disabledRules,
             externalJarPaths,
             baselinePath,
@@ -136,6 +140,7 @@ class KtlintConfigForm(private val project: Project, private val config: KtlintC
         config.treatAsErrors = AnnotationMode.ERROR == annotateAs.selectedItem
         config.hideErrors = AnnotationMode.NONE == annotateAs.selectedItem
         config.lintAfterReformat = lintAfterReformat.isSelected
+        config.formatOnSave = formatOnSave.isSelected
         config.disabledRules = disabledRules.text
             .split(",")
             .map { it.trim() }
@@ -158,6 +163,7 @@ class KtlintConfigForm(private val project: Project, private val config: KtlintC
         enableExperimental.isSelected = config.useExperimental
         annotateAs.selectedItem = AnnotationMode.fromConfig(config)
         lintAfterReformat.isSelected = config.lintAfterReformat
+        formatOnSave.isSelected = config.formatOnSave
         disabledRules.text = config.disabledRules.joinToString(", ")
         externalJarPaths.text = config.externalJarPaths.joinToString(", ")
         editorConfigPath.text = config.editorConfigPath ?: ""
@@ -170,6 +176,7 @@ class KtlintConfigForm(private val project: Project, private val config: KtlintC
                 Objects.equals(config.useExperimental, enableExperimental.isSelected) &&
                 Objects.equals(AnnotationMode.fromConfig(config), annotateAs.selectedItem) &&
                 Objects.equals(config.lintAfterReformat, lintAfterReformat.isSelected) &&
+                Objects.equals(config.formatOnSave, formatOnSave.isSelected) &&
                 Objects.equals(config.disabledRules, disabledRules.text) &&
                 Objects.equals(config.externalJarPaths, externalJarPaths.text) &&
                 Objects.equals(config.editorConfigPath, editorConfigPath.text)

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSave.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSave.kt
@@ -1,0 +1,25 @@
+package com.nbadal.ktlint
+
+import com.intellij.ide.actionsOnSave.impl.ActionsOnSaveFileDocumentManagerListener.ActionOnSave
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.idea.core.util.toPsiFile
+
+class KtlintActionOnSave : ActionOnSave() {
+    override fun isEnabledForProject(project: Project): Boolean {
+        return project.config().formatOnSave
+    }
+
+    override fun processDocuments(project: Project, documents: Array<out Document>) {
+        if (!project.config().enableKtlint || !project.config().formatOnSave) return
+
+        val manager = FileDocumentManager.getInstance()
+        for (document in documents) {
+            val file = manager.getFile(document)
+            if (file != null && file.isKotlinFile()) {
+                file.toPsiFile(project)?.let { psiFile -> doLint(psiFile, project.config(), true) }
+            }
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSaveInfoProvider.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSaveInfoProvider.kt
@@ -1,0 +1,51 @@
+package com.nbadal.ktlint
+
+import com.intellij.ide.actionsOnSave.*
+
+private const val ACTION_ON_SAVE_NAME = "Reformat with ktlint"
+private const val KTLINT_CONFIGURABLE_ID = "preferences.ktlint"
+
+class KtlintActionOnSaveInfoProvider : ActionOnSaveInfoProvider() {
+    override fun getActionOnSaveInfos(context: ActionOnSaveContext): List<ActionOnSaveInfo> = listOf(KtlintOnSaveActionInfo(context))
+
+    override fun getSearchableOptions(): Collection<String> {
+        return listOf(ACTION_ON_SAVE_NAME)
+    }
+}
+
+private class KtlintOnSaveActionInfo(actionOnSaveContext: ActionOnSaveContext) :
+    ActionOnSaveBackedByOwnConfigurable<KtlintConfig>(
+        actionOnSaveContext,
+        KTLINT_CONFIGURABLE_ID,
+        KtlintConfig::class.java
+    ) {
+
+    override fun getActionOnSaveName() = ACTION_ON_SAVE_NAME
+
+    override fun getCommentAccordingToStoredState() =
+        getComment(project.config().enableKtlint)
+
+    override fun getCommentAccordingToUiState(configurable: KtlintConfig) =
+        getComment(configurable.enableKtlintCheckbox.isSelected)
+
+    private fun getComment(ktlintEnabled: Boolean): ActionOnSaveComment? {
+        if (!ktlintEnabled) {
+            val message = "Ktlint is not enabled"
+            // no need to show warning if save action is disabled
+            return if (isActionOnSaveEnabled) ActionOnSaveComment.warning(message) else ActionOnSaveComment.info(message)
+        }
+
+        return null
+    }
+
+    override fun isActionOnSaveEnabledAccordingToStoredState() = project.config().formatOnSave
+
+    override fun isActionOnSaveEnabledAccordingToUiState(configurable: KtlintConfig) =
+        configurable.formatOnSaveCheckbox.isSelected
+
+    override fun setActionOnSaveEnabled(configurable: KtlintConfig, enabled: Boolean) {
+        configurable.formatOnSaveCheckbox.isSelected = enabled
+    }
+
+    override fun getActionLinks() = listOf(createGoToPageInSettingsLink(KTLINT_CONFIGURABLE_ID))
+}

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfig.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfig.kt
@@ -10,6 +10,10 @@ class KtlintConfig(private val project: Project) : SearchableConfigurable {
 
     private val form = KtlintConfigForm(project, project.config())
 
+    val formatOnSaveCheckbox by form::formatOnSave
+
+    val enableKtlintCheckbox by form::enableKtlint
+
     override fun createComponent(): JComponent = form.createComponent()
 
     override fun isModified() = form.isModified

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfigStorage.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfigStorage.kt
@@ -30,6 +30,9 @@ class KtlintConfigStorage : PersistentStateComponent<KtlintConfigStorage> {
     var lintAfterReformat = true
 
     @Tag
+    var formatOnSave = false
+
+    @Tag
     var disabledRules: List<String> = emptyList()
 
     @Tag
@@ -50,6 +53,7 @@ class KtlintConfigStorage : PersistentStateComponent<KtlintConfigStorage> {
         this.treatAsErrors = state.treatAsErrors
         this.hideErrors = state.hideErrors
         this.lintAfterReformat = state.lintAfterReformat
+        this.formatOnSave = state.formatOnSave
         this.disabledRules = state.disabledRules
         this.baselinePath = state.baselinePath
         this.editorConfigPath = state.editorConfigPath

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/Utils.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/Utils.kt
@@ -1,5 +1,8 @@
 package com.nbadal.ktlint
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 
 fun Project.config(): KtlintConfigStorage = getService(KtlintConfigStorage::class.java)
+
+fun VirtualFile.isKotlinFile(): Boolean = extension in setOf("kt", "kts")

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.nbadal.ktlint.config
 import com.nbadal.ktlint.doLint
+import com.nbadal.ktlint.isKotlinFile
 
 class FormatAction : AnAction() {
     override fun update(event: AnActionEvent) {
@@ -29,7 +30,7 @@ class FormatAction : AnAction() {
     private fun lintFile(project: Project, file: VirtualFile) {
         if (file.isDirectory) {
             file.children.forEach { lintFile(project, it) }
-        } else if (file.extension in setOf("kt", "kts")) {
+        } else if (file.isKotlinFile()) {
             PsiManager.getInstance(project).findFile(file)?.let {
                 doLint(it, project.config(), true)
             }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,9 @@
                              instance="com.nbadal.ktlint.KtlintConfig"/>
         <errorHandler implementation="com.nbadal.ktlint.KtlintErrorHandler" />
         <notificationGroup id="ktlint Notifications" displayType="BALLOON"/>
+        <actionOnSaveInfoProvider implementation="com.nbadal.ktlint.KtlintActionOnSaveInfoProvider"
+                                  order="after FormatOnSaveInfoProvider"/>
+        <actionOnSave implementation="com.nbadal.ktlint.KtlintActionOnSave" order="after FormatOnSaveAction"/>
     </extensions>
 
     <actions>

--- a/plugin/src/main/resources/strings.properties
+++ b/plugin/src/main/resources/strings.properties
@@ -16,3 +16,5 @@ annotateAsLabel=Annotate ktlint errors as:
 annotateNone=None
 annotateWarning=Warning
 annotateError=Error
+formatOnSaveText=Run ktlint --format on save
+formatOnSaveTooltip=Run the ktlint formatter after saving a file in the IDE


### PR DESCRIPTION
This implements the ActionOnSave extension causing Ktlint reformatting to show up as an option under the "Actions on Save" settings page.

This resolves issue #125 