### PR TITLE
Add null check for virtualFile in invoke function

### DIFF
--- a/plugin/src/main/kotlin/com/nbadal/ktlint/intentions/FormatIntention.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/intentions/FormatIntention.kt
@@ -18,7 +18,9 @@ class FormatIntention : BaseIntentionAction(), HighPriorityAction {
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         file?.let {
-            doLint(it, project.config(), true)
+            if (it.virtualFile != null) {
+                doLint(it, project.config(), true)
+            }
         }
     }
 }


### PR DESCRIPTION
Hello.

this PR is about [issues/310](https://github.com/nbadal/ktlint-intellij-plugin/issues/310)

I encounter the same issue every time I use ktlint.

Actually, virtualFile can be null. Due to the lack of validation on this part, an error occurs, and if an error occurs, the lint won't be executed anyway. Therefore, I fixed this part.

