### PR TITLE
Show notification when `.editorconfig` can not be parsed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.{kt,kts}]
+ktlint_code_style = kotlin_official
+ktlint_standard = enabled
+ktlint_experimental = enabled

--- a/plugin/src/main/java/KtlintConfigForm.kt
+++ b/plugin/src/main/java/KtlintConfigForm.kt
@@ -16,7 +16,10 @@ import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-class KtlintConfigForm(private val project: Project, private val ktlintConfigStorage: KtlintConfigStorage) {
+class KtlintConfigForm(
+    private val project: Project,
+    private val ktlintConfigStorage: KtlintConfigStorage,
+) {
     private lateinit var mainPanel: JPanel
     private var ktlintMode = NOT_INITIALIZED
     lateinit var enableKtlint: JCheckBox
@@ -74,12 +77,14 @@ class KtlintConfigForm(private val project: Project, private val ktlintConfigSto
                 DISABLED
             }
         ktlintConfigStorage.externalJarPaths =
-            externalJarPaths.text
+            externalJarPaths
+                .text
                 .split(",")
                 .map { it.trim() }
                 .filter { it.isNotBlank() }
         ktlintConfigStorage.baselinePath =
-            baselinePath.text
+            baselinePath
+                .text
                 .trim()
                 .let { it.ifBlank { null } }
     }

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSave.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSave.kt
@@ -8,9 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiManager
 
 class KtlintActionOnSave : ActionOnSave() {
-    override fun isEnabledForProject(project: Project): Boolean {
-        return project.ktlintEnabled()
-    }
+    override fun isEnabledForProject(project: Project): Boolean = project.ktlintEnabled()
 
     override fun processDocuments(
         project: Project,

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSaveInfoProvider.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintActionOnSaveInfoProvider.kt
@@ -17,8 +17,9 @@ class KtlintActionOnSaveInfoProvider : ActionOnSaveInfoProvider() {
     }
 }
 
-private class KtlintOnSaveActionInfo(actionOnSaveContext: ActionOnSaveContext) :
-    ActionOnSaveBackedByOwnConfigurable<KtlintConfig>(
+private class KtlintOnSaveActionInfo(
+    actionOnSaveContext: ActionOnSaveContext,
+) : ActionOnSaveBackedByOwnConfigurable<KtlintConfig>(
         actionOnSaveContext,
         KTLINT_FORMAT_CONFIGURABLE_ID,
         KtlintConfig::class.java,

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfig.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfig.kt
@@ -6,7 +6,9 @@ import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import javax.swing.JComponent
 
-class KtlintConfig(private val project: Project) : SearchableConfigurable {
+class KtlintConfig(
+    private val project: Project,
+) : SearchableConfigurable {
     private val form = KtlintConfigForm(project, project.config())
 
     val enableKtlintCheckbox by form::enableKtlint

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfigStorage.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfigStorage.kt
@@ -121,7 +121,9 @@ class KtlintConfigStorage : PersistentStateComponent<KtlintConfigStorage> {
         DISABLED,
     }
 
-    data class RuleSetProviders(val externalJarPaths: List<String>) {
+    data class RuleSetProviders(
+        val externalJarPaths: List<String>,
+    ) {
         private var _error: String? = null
 
         val error: String?
@@ -146,7 +148,9 @@ class KtlintConfigStorage : PersistentStateComponent<KtlintConfigStorage> {
             }
     }
 
-    data class Baseline(val baselinePath: String?) {
+    data class Baseline(
+        val baselinePath: String?,
+    ) {
         val lintErrorsPerFile: Map<String, List<KtlintCliError>> =
             baselinePath
                 ?.let { path ->

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintErrorHandler.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintErrorHandler.kt
@@ -21,11 +21,12 @@ class KtlintErrorHandler : ErrorReportSubmitter() {
         consumer: Consumer<in SubmittedReportInfo>,
     ): Boolean {
         val config =
-            withAccessToken(BuildConfig.ROLLBAR_ACCESS_TOKEN).apply {
-                environment("production")
-                appPackages(listOf(BuildConfig.NAME))
-                codeVersion(BuildConfig.VERSION)
-            }.build()
+            withAccessToken(BuildConfig.ROLLBAR_ACCESS_TOKEN)
+                .apply {
+                    environment("production")
+                    appPackages(listOf(BuildConfig.NAME))
+                    codeVersion(BuildConfig.VERSION)
+                }.build()
 
         val rollbar = Rollbar.init(config)
         events.forEach { event ->

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
@@ -11,9 +11,9 @@ import com.pinterest.ktlint.rule.engine.api.Code
 import com.pinterest.ktlint.rule.engine.api.KtLintParseException
 import com.pinterest.ktlint.rule.engine.api.KtLintRuleException
 import com.pinterest.ktlint.rule.engine.api.LintError
+import org.ec4j.core.parser.ParseException
 import java.nio.file.Files
 import java.nio.file.Path
-import org.ec4j.core.parser.ParseException
 
 internal fun ktlintLint(
     psiFile: PsiFile,
@@ -138,7 +138,7 @@ private fun executeKtlintFormat(
             project = project,
             title = "KtLintRuleException",
             message =
-            """
+                """
                 An error occurred in a rule. Please see stacktrace below for rule that caused the problem and contact maintainer of the
                 rule when the error can be reproduced.
                 ${ktLintRuleException.stackTraceToString()}

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
@@ -13,6 +13,7 @@ import com.pinterest.ktlint.rule.engine.api.KtLintRuleException
 import com.pinterest.ktlint.rule.engine.api.LintError
 import java.nio.file.Files
 import java.nio.file.Path
+import org.ec4j.core.parser.ParseException
 
 internal fun ktlintLint(
     psiFile: PsiFile,
@@ -46,7 +47,6 @@ internal fun ktlintFormat(
 
 private fun PsiFile.canBeProcessed() =
     if (virtualFile == null) {
-        println("prevent NPE")
         false
     } else {
         virtualFile != null &&
@@ -138,10 +138,32 @@ private fun executeKtlintFormat(
             project = project,
             title = "KtLintRuleException",
             message =
-                """
+            """
                 An error occurred in a rule. Please see stacktrace below for rule that caused the problem and contact maintainer of the
                 rule when the error can be reproduced.
                 ${ktLintRuleException.stackTraceToString()}
+                """.trimIndent(),
+        )
+        return EMPTY_LINT_ERRORS
+    } catch (parseException: ParseException) {
+        KtlintNotifier.notifyError(
+            project = project,
+            title = "Invalid editorconfig",
+            message =
+                """
+                An error occurred while reading the '.editorconfig':
+                ${parseException.message}
+                """.trimIndent(),
+        )
+        return EMPTY_LINT_ERRORS
+    } catch (exception: Exception) {
+        KtlintNotifier.notifyError(
+            project = project,
+            title = "Invalid editorconfig",
+            message =
+                """
+                An error occurred while processing file '${psiFile.virtualFile.path}':
+                ${exception.printStackTrace()}
                 """.trimIndent(),
         )
         return EMPTY_LINT_ERRORS

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintLoadRuleProviders.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintLoadRuleProviders.kt
@@ -31,8 +31,7 @@ private fun <T> Class<T>.loadFromJarFiles(
                     .also { providers -> println("Loaded ${providers.size} providers from $url") }
                     .filterNot { providerIdsFromKtlintJars.contains(providerId(it)) }
                     .filterNotNull()
-            }
-            .toSet()
+            }.toSet()
     return providersFromKtlintJars
         .plus(providersFromCustomJars)
         .filterNotNull()

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintNotifier.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintNotifier.kt
@@ -40,7 +40,9 @@ object KtlintNotifier {
         .getNotificationGroup(KTLINT_NOTIFICATION_GROUP)
         .createNotification(title, message, notificationType)
 
-    private class OpenSettingsAction(val project: Project) : NotificationAction("Open ktlint settings...") {
+    private class OpenSettingsAction(
+        val project: Project,
+    ) : NotificationAction("Open ktlint settings...") {
         override fun actionPerformed(
             e: AnActionEvent,
             notification: Notification,

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
@@ -31,7 +31,9 @@ class FormatAction : AnAction() {
         }
     }
 
-    class KtlintFormatContentIterator(val project: Project) : ContentIterator {
+    class KtlintFormatContentIterator(
+        val project: Project,
+    ) : ContentIterator {
         override fun processFile(fileOrDir: VirtualFile): Boolean {
             fileOrDir
                 .takeUnless { it.isDirectory }

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/KtlintModeIntention.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/KtlintModeIntention.kt
@@ -11,7 +11,10 @@ import com.nbadal.ktlint.KtlintConfigStorage
 import com.nbadal.ktlint.KtlintConfigStorage.KtlintMode.ENABLED
 import com.nbadal.ktlint.config
 
-class KtlintModeIntention(private val ktlintMode: KtlintConfigStorage.KtlintMode) : BaseIntentionAction(), LowPriorityAction {
+class KtlintModeIntention(
+    private val ktlintMode: KtlintConfigStorage.KtlintMode,
+) : BaseIntentionAction(),
+    LowPriorityAction {
     override fun getFamilyName() = "KtLint"
 
     override fun getText() =

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/KtlintRuleSuppressIntention.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/KtlintRuleSuppressIntention.kt
@@ -24,7 +24,10 @@ import com.nbadal.ktlint.elementTypeName
 import com.nbadal.ktlint.findElementType
 import com.pinterest.ktlint.rule.engine.api.LintError
 
-class KtlintRuleSuppressIntention(private val lintError: LintError) : BaseIntentionAction(), HighPriorityAction {
+class KtlintRuleSuppressIntention(
+    private val lintError: LintError,
+) : BaseIntentionAction(),
+    HighPriorityAction {
     override fun getFamilyName() = "KtLint"
 
     override fun getText() = "Suppress '${lintError.ruleId.value}'"


### PR DESCRIPTION
Inform user about problem in `.editorconfig` when it can not be parsed succesfully.

Closes #378