### PR TITLE
Do not show violations which can be autocorrected

### DIFF
--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
@@ -20,7 +20,7 @@ internal fun ktlintLint(
     psiFile: PsiFile,
     triggeredBy: String,
 ) = if (psiFile.virtualFile.isKotlinFile()) {
-    executeKtlintFormat(psiFile, triggeredBy, false)
+    executeKtlintFormat(psiFile, triggeredBy, false, force = true)
 } else {
     EMPTY_LINT_ERRORS
 }
@@ -51,10 +51,10 @@ private fun executeKtlintFormat(
     psiFile: PsiFile,
     triggeredBy: String,
     writeFormattedCode: Boolean = false,
-    forceFormat: Boolean = false,
+    force: Boolean = false,
 ): List<LintError> {
     val project = psiFile.project
-    if (project.config().ktlintMode != ENABLED && !forceFormat) {
+    if (project.config().ktlintMode != ENABLED && !force) {
         return EMPTY_LINT_ERRORS
     }
 

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/ForceFormatIntention.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/ForceFormatIntention.kt
@@ -1,0 +1,40 @@
+package com.nbadal.ktlint.actions
+
+import com.intellij.codeInsight.intention.FileModifier
+import com.intellij.codeInsight.intention.LowPriorityAction
+import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.nbadal.ktlint.ktlintFormat
+
+/**
+ * Intention to format the code with ktlint, regardless whether the plugin is enabled/disabled.
+ */
+class ForceFormatIntention :
+    BaseIntentionAction(),
+    LowPriorityAction {
+    override fun getFamilyName() = "KtLint"
+
+    override fun getText() = "Format file with ktlint"
+
+    override fun isAvailable(
+        project: Project,
+        editor: Editor?,
+        psiFile: PsiFile,
+    ): Boolean = true
+
+    /**
+     * As [isAvailable] return true always, the [invoke] is also called when previewing the result of the intention unless this function
+     * returns null. This prevents that the code if formatted unintentionally.
+     */
+    override fun getFileModifierForPreview(target: PsiFile): FileModifier? = null
+
+    override fun invoke(
+        project: Project,
+        editor: Editor?,
+        psiFile: PsiFile,
+    ) {
+        ktlintFormat(psiFile, "ForceFormatIntention", forceFormat = true)
+    }
+}


### PR DESCRIPTION
Do not show violations which can be autocorrected / add intention to format file

Violations which can be autocorrected should never be displayed. They are distracting, and it could lead to developers starting to fix the issues manually. A (weak) warning is displayed, with the number of errors that can be autocorrected. On this warning, an intention is shown to format the file. This intention is also available in case the plugin is not enabled.