### PR TITLE
Print logging to STDOUT based on environment variable

### DIFF
--- a/.run/Run Plugin.run.xml
+++ b/.run/Run Plugin.run.xml
@@ -2,6 +2,11 @@
   <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
     <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
     <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="KTLINT_PLUGIN_LOG_TO_STDOUT" value="true" />
+        </map>
+      </option>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintAnnotator.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintAnnotator.kt
@@ -24,6 +24,8 @@ import com.nbadal.ktlint.actions.ShowAllKtlintViolationsIntention
 import com.pinterest.ktlint.rule.engine.api.LintError
 
 internal class KtlintAnnotator : ExternalAnnotator<List<LintError>, List<LintError>>() {
+    private val logger = KtlintLogger(this::class.qualifiedName)
+
     override fun collectInformation(
         psiFile: PsiFile,
         editor: Editor,
@@ -43,7 +45,7 @@ internal class KtlintAnnotator : ExternalAnnotator<List<LintError>, List<LintErr
                 if (editor.document.ktlintAnnotatorUserData?.modificationTimestamp == editor.document.modificationStamp) {
                     // Document is unchanged since last time ktlint has run. Reuse lint errors from user data. It also has the advantage that
                     // a notification from the lint/format process in case on error is not displayed again.
-                    println("Do not run ktlint as ktlintAnnotatorUserData has not changed on document ${psiFile.virtualFile.name}")
+                    logger.debug { "Do not run ktlint as ktlintAnnotatorUserData has not changed on document ${psiFile.virtualFile.name}" }
                     editor.document.ktlintAnnotatorUserData?.lintErrors
                 } else {
                     ktlintLint(psiFile, "KtlintAnnotator")
@@ -156,7 +158,7 @@ internal class KtlintAnnotator : ExternalAnnotator<List<LintError>, List<LintErr
                 .document
                 .ktlintAnnotatorUserData
                 .also {
-                    println("Annotator: $it")
+                    logger.debug { "Annotator: $it" }
                 }?.displayAllKtlintViolations ?: false
 
     private fun LintError.errorMessage(): String = "$detail (${ruleId.value})"

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfigStorage.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintConfigStorage.kt
@@ -15,6 +15,8 @@ import com.pinterest.ktlint.rule.engine.core.api.propertyTypes
 import java.io.File
 import java.nio.file.Path
 
+private val logger = KtlintLogger(KtlintConfigStorage::class.qualifiedName)
+
 @State(
     name = "KtLint plugin",
     storages = [Storage("ktlint-plugin.xml")],
@@ -146,8 +148,8 @@ class KtlintConfigStorage : PersistentStateComponent<KtlintConfigStorage> {
                 ?.let { path ->
                     loadBaseline(path)
                         .lintErrorsPerFile
-                        .also { println("Load baseline from file '$path'") }
+                        .also { logger.debug { "Load baseline from file '$path'" } }
                 }
-                ?: emptyMap<String, List<KtlintCliError>>().also { println("Clear baseline") }
+                ?: emptyMap<String, List<KtlintCliError>>().also { logger.debug { "Clear baseline" } }
     }
 }

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintFormat.kt
@@ -20,6 +20,8 @@ import org.ec4j.core.parser.ParseException
 import java.nio.file.Files
 import java.nio.file.Path
 
+private val logger = KtlintLogger("com.nbdal.ktlint.KtlintFormat")
+
 internal fun ktlintLint(
     psiFile: PsiFile,
     triggeredBy: String,
@@ -64,7 +66,7 @@ private fun executeKtlintFormat(
         return KtlintResult(NOT_STARTED)
     }
 
-    println("Start ktlintFormat on file '${psiFile.virtualFile.name}' triggered by '$triggeredBy'")
+    logger.debug { "Start ktlintFormat on file '${psiFile.virtualFile.name}' triggered by '$triggeredBy'" }
 
     project
         .config()
@@ -115,7 +117,7 @@ private fun executeKtlintFormat(
                         //  instead of the real name of the file. With fix in Ktlint 1.1.0 the filename will be based on
                         //  parameter "path" and the rule will no longer cause false positives.
                         error.ruleId.value == "standard:filename" -> {
-                            println("Ignore rule '${error.ruleId.value}'")
+                            logger.debug { "Ignore rule '${error.ruleId.value}'" }
                         }
 
                         error.isIgnoredInBaseline(baselineErrors) -> Unit
@@ -123,12 +125,12 @@ private fun executeKtlintFormat(
                     }
                 }
                 ?: return KtlintResult(FILE_RELATED_ERROR)
-                    .also { println("Could not create ktlintRuleEngine for path '${psiFile.virtualFile.path}'") }
+                    .also { logger.debug { "Could not create ktlintRuleEngine for path '${psiFile.virtualFile.path}'" } }
         if (writeFormattedCode && formattedCode != code.content) {
             psiFile.viewProvider.document.setText(formattedCode)
             fileChangedByFormat = true
         }
-        println("Finished ktlintFormat on file '${psiFile.virtualFile.name}' triggered by '$triggeredBy' successfully")
+        logger.debug { "Finished ktlintFormat on file '${psiFile.virtualFile.name}' triggered by '$triggeredBy' successfully" }
         return KtlintResult(SUCCESS, lintErrors, fileChangedByFormat)
     } catch (ktLintParseException: KtLintParseException) {
         // Most likely the file contains a compilation error which prevents it from being parsed. The user should resolve those errors.

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintLoadRuleProviders.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintLoadRuleProviders.kt
@@ -8,6 +8,8 @@ import java.net.URLClassLoader
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 
+private val logger = KtlintLogger("com.nbdal.ktlint.KtlintLoadRuleProviders")
+
 // See: LoadRuleProviders.kt
 internal fun List<URL>.loadRuleProviders(): Set<RuleProvider> =
     RuleSetProviderV3::class.java
@@ -21,7 +23,7 @@ private fun <T> Class<T>.loadFromJarFiles(
     providerId: (T) -> String,
 ): Set<T> {
     val providersFromKtlintJars = this.loadProvidersFromJars(null)
-    println("Loaded ${providersFromKtlintJars.size} providers from ktlint jars")
+    logger.debug { "Loaded ${providersFromKtlintJars.size} providers from ktlint jars" }
     val providerIdsFromKtlintJars = providersFromKtlintJars.map { providerId(it) }
     val providersFromCustomJars =
         urls
@@ -29,7 +31,7 @@ private fun <T> Class<T>.loadFromJarFiles(
             .flatMap { url ->
                 loadProvidersFromJars(url)
                     .filterNot { providerId(it) in providerIdsFromKtlintJars }
-                    .also { providers -> println("Loaded ${providers.size} custom ruleset providers from $url") }
+                    .also { providers -> logger.debug { "Loaded ${providers.size} custom ruleset providers from $url" } }
                     .filterNotNull()
                     .ifEmpty { throw EmptyRuleSetJarException("Custom rule set '$url' does not contain a custom ktlint rule set provider") }
             }.toSet()

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintLogger.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/KtlintLogger.kt
@@ -1,0 +1,50 @@
+package com.nbadal.ktlint
+
+import com.intellij.openapi.diagnostic.DefaultLogger
+
+@Suppress("unused")
+class KtlintLogger(
+    qualifiedName: String?,
+) : DefaultLogger(qualifiedName ?: "ktlint-intellij-plugin") {
+    fun debug(
+        throwable: Throwable? = null,
+        message: () -> String?,
+    ) {
+        logToStdOut(message = message(), throwable = throwable) ?: super.debug(message(), throwable)
+    }
+
+    fun info(
+        throwable: Throwable? = null,
+        message: () -> String?,
+    ) {
+        logToStdOut(message = message(), throwable = throwable) ?: super.info(message(), throwable)
+    }
+
+    fun warn(
+        throwable: Throwable? = null,
+        message: () -> String?,
+    ) {
+        logToStdOut(message = message(), throwable = throwable) ?: super.warn(message(), throwable)
+    }
+
+    fun error(
+        throwable: Throwable? = null,
+        message: () -> String?,
+    ) {
+        logToStdOut(message = message(), throwable = throwable) ?: super.error(message(), throwable)
+    }
+
+    private fun logToStdOut(
+        message: String? = null,
+        throwable: Throwable? = null,
+    ) = if (System.getenv(KTLINT_PLUGIN_LOG_TO_STDOUT).equals("true", ignoreCase = true)) {
+        message?.let { println(message) }
+        throwable?.let { println(throwable) }
+    } else {
+        null
+    }
+
+    companion object {
+        const val KTLINT_PLUGIN_LOG_TO_STDOUT = "KTLINT_PLUGIN_LOG_TO_STDOUT"
+    }
+}

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/Logger.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/Logger.kt
@@ -1,0 +1,2 @@
+const val enabled = true
+


### PR DESCRIPTION
Print logging to stdout when environment variable KTLINT_PLUGIN_LOG_TO_STDOUT is set to true. Use intellij default logger otherwise

This environment variables eases local development (when set in the run configuration of the plugin) as the debug logging does not need to be enabled manually anymore.

Closes #408