### PR TITLE
Fix slf4j dependency problem on startup of IDEA

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kover = "0.7.6"
 ktlint = "1.2.2-SNAPSHOT"
 qodana = "0.1.13"
 shadow = "8.1.1"
+slf4j="2.0.13"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
@@ -18,6 +19,7 @@ ktlintRuleEngine = {  group = "com.pinterest.ktlint", name = "ktlint-rule-engine
 ktlintCliRulesetCore = {  group = "com.pinterest.ktlint", name = "ktlint-cli-ruleset-core", version.ref = "ktlint" }
 ktlintCliReporterCore = {  group = "com.pinterest.ktlint", name = "ktlint-cli-reporter-core", version.ref = "ktlint" }
 ktlintCliReporterBaselineCore = {  group = "com.pinterest.ktlint", name = "ktlint-cli-reporter-baseline", version.ref = "ktlint" }
+slf4j-api = {  group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 
 [plugins]
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" } # BuildConfig - read more: https://github.com/gmazzo/gradle-buildconfig-plugin

--- a/ktlint-lib/ruleset-0-50-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-0-50-0/build.gradle.kts
@@ -15,8 +15,27 @@ repositories {
 dependencies {
     // Until version 0.50.0, the "mu.Kotlin" logger was used. In 1.x version this has been replaced with
     // "io.github.oshai.kotlinlogging.KLogger".
-    implementation("com.pinterest.ktlint:ktlint-logger:0.50.0")
-    implementation("com.pinterest.ktlint:ktlint-ruleset-standard:0.50.0")
+    constraints {
+        runtimeOnly(libs.slf4j.api) {
+            because(
+                "Transitive ktlint logging dependency (2.0.3) does not use the module classloader in ServiceLoader. Replace with newer SLF4J version",
+            )
+        }
+    }
+    implementation("com.pinterest.ktlint:ktlint-logger:0.50.0") {
+        // Exclude the slf4j 2.0.3 version provided via Ktlint as it does not use the module classloader in the ServiceLoader
+        exclude("org.slf4j")
+            .because(
+                "Transitive ktlint logging dependency (2.0.3) does not use the module classloader in ServiceLoader. Replace with newer SLF4J version",
+            )
+    }
+    implementation("com.pinterest.ktlint:ktlint-ruleset-standard:0.50.0") {
+        // Exclude the slf4j 2.0.3 version provided via Ktlint as it does not use the module classloader in the ServiceLoader
+        exclude("org.slf4j")
+            .because(
+                "Transitive ktlint logging dependency (2.0.3) does not use the module classloader in ServiceLoader. Replace with newer SLF4J version",
+            )
+    }
 }
 
 tasks {


### PR DESCRIPTION
When starting Intellij IDEA and rule providers were loaded, an error was displayed because ruleset version `0.50.0` had a transitive dependency on `slf4j` version 2.0.3 which did not use the classloader in the ServiceLoader.

Closes #510