### PR TITLE
Upgrade platform version to 2022.3 / Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,12 +13,12 @@ pluginRepositoryUrl = https://github.com/nbadal/ktlint-intellij-plugin
 pluginVersion = 0.23.0-beta-1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 213
+pluginSinceBuild = 223
 pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2021.3
+platformVersion = 2022.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/ktlint-lib/build.gradle.kts
+++ b/ktlint-lib/build.gradle.kts
@@ -42,13 +42,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/core/build.gradle.kts
+++ b/ktlint-lib/core/build.gradle.kts
@@ -15,13 +15,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/ruleset-0-50-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-0-50-0/build.gradle.kts
@@ -39,13 +39,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/ruleset-1-0-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-0-1/build.gradle.kts
@@ -17,13 +17,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/ruleset-1-1-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-1-1/build.gradle.kts
@@ -17,13 +17,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/ruleset-1-2-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-0/build.gradle.kts
@@ -17,13 +17,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/ruleset-1-2-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-1/build.gradle.kts
@@ -17,13 +17,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/ktlint-lib/ruleset-1-2-2/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-2/build.gradle.kts
@@ -19,13 +19,12 @@ dependencies {
 }
 
 tasks {
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<ShadowJar> {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 kotlin {
     @Suppress("UnstableApiUsage")
     jvmToolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
         vendor = JvmVendorSpec.JETBRAINS
     }
 }
@@ -133,14 +133,13 @@ tasks {
     //   }
     // Replace with JavaCompile and KotlintCompile tasks
 
-    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
 
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     named<Test>("test") {

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
@@ -1,5 +1,6 @@
 package com.nbadal.ktlint.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -22,6 +23,8 @@ import com.nbadal.ktlint.ktlintFormat
 import com.nbadal.ktlint.ktlintMode
 
 class FormatAction : AnAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
     override fun update(event: AnActionEvent) {
         val project = event.getData(CommonDataKeys.PROJECT) ?: return
         val files = event.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY) ?: return

--- a/plugin/src/main/kotlin/com/nbadal/ktlint/actions/LintAction.kt
+++ b/plugin/src/main/kotlin/com/nbadal/ktlint/actions/LintAction.kt
@@ -1,6 +1,7 @@
 package com.nbadal.ktlint.actions
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -8,6 +9,8 @@ import com.nbadal.ktlint.isKotlinFile
 import com.nbadal.ktlint.setDisplayAllKtlintViolations
 
 class LintAction : AnAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
     override fun update(event: AnActionEvent) {
         val virtualFile = event.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
 


### PR DESCRIPTION
The ActionUpdateThread needs to be set explicitly. The default OLD_EDT mode is deprecated and will be removed.

Closes #509