### PR TITLE
Support publication of dev versions

### DIFF
--- a/create-ktlint-plugin-zip.sh
+++ b/create-ktlint-plugin-zip.sh
@@ -8,8 +8,10 @@ function getGradleProperty {
     echo $PROPERTY_VALUE
 }
 
-if [ $(find plugin/build/idea-sandbox/plugins -name instrumented*.jar | wc -l | cut -w -f 2) -eq 1 ]; then
-  PLUGIN_VERSION=$(getGradleProperty "pluginVersion")
+INSTRUMENTED_JAR_FILE_NAME=$(find plugin/build/idea-sandbox/plugins -name instrumented*.jar)
+if [ $(echo ${INSTRUMENTED_JAR_FILE_NAME} | wc -l | cut -w -f 2) -eq 1 ]; then
+  INSTRUMENTED_JAR_FILE_NAME_WITHOUT_EXTENSION=${INSTRUMENTED_JAR_FILE_NAME%*.jar}
+  PLUGIN_VERSION=${INSTRUMENTED_JAR_FILE_NAME_WITHOUT_EXTENSION##*-plugin-}
   PLUGIN_ZIP_FILE_NAME=ktlint-plugin-${PLUGIN_VERSION}.zip
   (cd plugin/build/idea-sandbox/plugins && zip  -r ../../${PLUGIN_ZIP_FILE_NAME} ktlint)
   echo "Created ZIP file ./plugin/build/${PLUGIN_ZIP_FILE_NAME}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,11 @@ pluginRepositoryUrl = https://github.com/nbadal/ktlint-intellij-plugin
 # When the version is suffixed with "-beta" than the plugin is published to the "beta" channel of the marketplace. Same for "eap" or any
 # other value. See https://plugins.jetbrains.com/docs/intellij/publishing-plugin.html#specifying-a-release-channel
 # Users need to specify an additional repository to pick up publications from the non default channel. For example:
+# - https://plugins.jetbrains.com/plugins/list?channel=dev&pluginId=com.nbadal.ktlint
 # - https://plugins.jetbrains.com/plugins/list?channel=beta&pluginId=com.nbadal.ktlint
-pluginVersion = 0.23.0-beta-1
+# The dev channel is meant for plugin developers. It contains the bleeding edge version of the plugin. Note that the pluginVersion for the
+# beta/dev channel is automatically expanded with the build timestamp
+pluginVersion = 0.23.0-dev
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213


### PR DESCRIPTION
A dev-version is published on the new dev channel to the plugin. As plugin developer it becomes easier to keep using the last plugin version as it can be installed from Jebrains marketplace.

The beta and dev version number are automatically expanded with a build timestamp to create unique and identifiable version numbers.