### PR TITLE
Add constraint on ec4j-core in ktlint ruleset until 1.3.1

### DIFF
--- a/ktlint-lib/ruleset-0-50-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-0-50-0/build.gradle.kts
@@ -20,6 +20,10 @@ dependencies {
                 "Transitive ktlint logging dependency (2.0.3) does not use the module classloader in ServiceLoader. Replace with newer SLF4J version",
             )
         }
+        // ec4-core version 0.3.0 which is included in ktlint 0.50.0 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
     }
     implementation("com.pinterest.ktlint:ktlint-logger:0.50.0") {
         // Exclude the slf4j 2.0.3 version provided via Ktlint as it does not use the module classloader in the ServiceLoader

--- a/ktlint-lib/ruleset-1-0-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-0-1/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard:1.0.1")
+
+    constraints {
+        // ec4-core version 0.3.0 which is included in ktlint 1.0.1 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
+    }
 }
 
 kotlin {

--- a/ktlint-lib/ruleset-1-1-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-1-1/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard:1.1.1")
+
+    constraints {
+        // ec4-core version 0.3.0 which is included in ktlint 1.1.1 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
+    }
 }
 
 kotlin {

--- a/ktlint-lib/ruleset-1-2-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-0/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard:1.2.0")
+
+    constraints {
+        // ec4-core version 0.3.0 which is included in ktlint 1.2.0 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
+    }
 }
 
 kotlin {

--- a/ktlint-lib/ruleset-1-2-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-1/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard:1.2.1")
+
+    constraints {
+        // ec4-core version 0.3.0 which is included in ktlint 1.2.1 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
+    }
 }
 
 kotlin {

--- a/ktlint-lib/ruleset-1-3-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-3-0/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard:1.3.0")
+
+    constraints {
+        // ec4-core version 0.3.0 which is included in ktlint 1.3.0 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
+    }
 }
 
 kotlin {

--- a/ktlint-lib/ruleset-1-3-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-3-1/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-ruleset-standard:1.3.1")
+
+    constraints {
+        // ec4-core version 0.3.0 which is included in ktlint 1.3.1 fails on '.editorconfig' properties without value
+        implementation("org.ec4j.core:ec4j-core:1.1.0") {
+            because("Allows '.editorconfig' properties to be defined without any value")
+        }
+    }
 }
 
 kotlin {


### PR DESCRIPTION
In ktlint 1.4.1 the ec4j-core was update from 0.3.0 to 1.1.0 to resolve an issue with '.editorconfig' properties without value. As multiple version of this dependency were available on the classpath of the plugin, the problem still occurred.