### PR TITLE
Set projectName explicitly to ktlint

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -95,6 +95,8 @@ dependencies {
 
 // Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
 intellijPlatform {
+    projectName.set("ktlint")
+
     pluginConfiguration {
         // Use publishPluginVersion which contains the build timestamp for release to non-default channel
         // Original:


### PR DESCRIPTION
When not set, the name of the project directory, e.g. "plugin" is used. This is confusing when looking at file system to which plugins are installed.

Closes #617 