### PR TITLE
Shadow all packages of "org.jetbrains" and "org.intellij"

### DIFF
--- a/ktlint-lib/build.gradle.kts
+++ b/ktlint-lib/build.gradle.kts
@@ -71,29 +71,13 @@ tasks {
         // Expose all ruleset implementations:
         mergeServiceFiles()
 
-        // Relocate to prevent conflicts with same packages provided by Intellij IDEA as well. The embeddable Kotlin compiler in the Ktlint
-        // jar differs from the compiler provided in the IDEA.
+        // Ktlint contains the embeddable Kotlin compiler. The Kotlin compiler brings in some packages from "org.jetbrains" and
+        // "org.intellij" which might conflict with the same packages provided by the Intellij IDEA Runtime environment. To avoid possible
+        // conflicts, the packages are shadowed so that ktlint can still use the embedded compiler, independently of the compiler which is
+        // provided in the Intellij IDEA runtime.
         // IMPORTANT: Third party suppliers of rule set need to add those relocations as well!
-        relocate("org.jetbrains.kotlin.psi.KtPsiFactory", "shadow.org.jetbrains.kotlin.psi.KtPsiFactory")
-        relocate("org.jetbrains.kotlin.psi.psiUtil", "shadow.org.jetbrains.kotlin.psi.psiUtil")
-
-        // From "compatability verification" (plugin verifier) results:
-        //     The plugin distribution bundles IDE packages
-        //       'org.jetbrains.org.objectweb.asm.signature',
-        //       'org.jetbrains.org.objectweb.asm.commons',
-        //       'org.jetbrains.org.objectweb.asm',
-        //       'org.jetbrains.org.objectweb.asm.util',
-        //       'org.jetbrains.org.objectweb',
-        //       'org.jetbrains.org.objectweb.asm.tree.analysis',
-        //       'org.jetbrains.concurrency',
-        //       'org.jetbrains.org.objectweb.asm.tree',
-        //       'org.jetbrains.org'.
-        //       Bundling IDE packages is considered bad practice and may lead to sophisticated compatibility problems. Consider excluding
-        //       these IDE packages from the plugin distribution. If your plugin depends on classes of an IDE bundled plugin, explicitly
-        //       specify dependency on that plugin instead of bundling it.
-        // IMPORTANT: Third party suppliers of rule set need to add those relocations as well!
-        relocate("org.jetbrains.org", "shadow.org.jetbrains.org")
-        relocate("org.jetbrains.concurrency", "shadow.org.jetbrains.concurrency")
+        relocate("org.jetbrains", "shadow.org.jetbrains")
+        relocate("org.intellij", "shadow.org.intellij")
 
         // Ktlint-lib itself may not be minimized as this would result in exceptions when loading custom rulesets as the RulesetProviderV3
         // can not be found


### PR DESCRIPTION
Shadow all packages of "org.jetbrains" and "org.intellij" in ktlint-lib to avoid potential conflicts with packages provided by Intellij IDEA runtime.

Potentially closes #614 