### PR TITLE
Minimize ruleset jars

### DIFF
--- a/ktlint-lib/ruleset-0-50-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-0-50-0/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -48,19 +46,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.logger",
-            "com.pinterest.ktlint-0-50-0.logger",
-        )
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V0_50_0",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.logger",
+        "com.pinterest.ktlint-0-50-0.logger",
+    )
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V0_50_0",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:0.50.0"))
-        }
-    }
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("com/sun/**")
+    exclude("gnu/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("mu/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-0-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-0-1/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -29,15 +27,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_0_1",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_0_1",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.0.1"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.0.1"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-1-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-1-1/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -29,15 +27,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_1_1",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_1_1",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.1.1"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.1.1"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-2-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-0/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -29,15 +27,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_2_0",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_2_0",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.2.0"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.2.0"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-2-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-2-1/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -29,15 +27,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_2_1",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_2_1",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.2.1"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.2.1"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-3-0/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-3-0/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -29,15 +27,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_3_0",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_3_0",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.3.0"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.3.0"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-3-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-3-1/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -29,15 +27,25 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_3_1",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_3_1",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.3.1"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.3.1"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }

--- a/ktlint-lib/ruleset-1-4-1/build.gradle.kts
+++ b/ktlint-lib/ruleset-1-4-1/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
@@ -22,15 +20,26 @@ kotlin {
     }
 }
 
-tasks {
-    withType<ShadowJar> {
-        relocate(
-            "com.pinterest.ktlint.ruleset.standard",
-            "com.pinterest.ktlint.ruleset.standard.V1_4_1",
-        )
+tasks.shadowJar {
+    relocate(
+        "com.pinterest.ktlint.ruleset.standard",
+        "com.pinterest.ktlint.ruleset.standard.V1_4_1",
+    )
 
-        minimize {
-            exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.4.1"))
-        }
+    minimize {
+        exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:1.4.1"))
     }
+
+    // Can not use the minimize block as that would build a fat jar. The GitHub runner has too little diskspace to build the project if a
+    // fat jar is build for each version of the ktlint rulesets. Also, the non-ktlint dependencies will not be used in the final ktlint-lib
+    // jar as the files of the latest ruleset will be used instead,
+    exclude("dev/**")
+    exclude("gnu/**")
+    exclude("io/**")
+    exclude("javaslang/**")
+    exclude("kotlin/**")
+    exclude("kotlinx/**")
+    exclude("messages/**")
+    exclude("misc/**")
+    exclude("org/**")
 }


### PR DESCRIPTION
GitHub runner runs out of diskspace which might be caused by the size and the number of fat jars for each pf the ktlint rulesets