### PR TITLE
Add support for ktlint editorconfig properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ pluginRepositoryUrl = https://github.com/nbadal/ktlint-intellij-plugin
 # - https://plugins.jetbrains.com/plugins/list?channel=beta&pluginId=com.nbadal.ktlint
 # The dev channel is meant for plugin developers. It contains the bleeding edge version of the plugin. Note that the pluginVersion for the
 # beta/dev channel is automatically expanded with the build timestamp
-pluginVersion = 0.28.0
+pluginVersion = 0.29.0-beta-1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # When supporting too many versions, the pluginVerifier task in the build crashes because it runs out of disk space as
@@ -29,7 +29,7 @@ platformVersion = 2024.1.7
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = org.editorconfig.editorconfigjetbrains
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.10.2

--- a/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/KtlintEditorConfigOptionDescriptorProvider.kt
+++ b/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/KtlintEditorConfigOptionDescriptorProvider.kt
@@ -1,0 +1,111 @@
+package com.nbadal.ktlint
+
+import com.intellij.openapi.project.Project
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
+import org.ec4j.core.model.PropertyType
+import org.editorconfig.language.extensions.EditorConfigOptionDescriptorProvider
+import org.editorconfig.language.schema.descriptors.EditorConfigDescriptor
+import org.editorconfig.language.schema.descriptors.EditorConfigMutableDescriptor
+import org.editorconfig.language.schema.descriptors.impl.EditorConfigConstantDescriptor
+import org.editorconfig.language.schema.descriptors.impl.EditorConfigOptionDescriptor
+import org.editorconfig.language.schema.descriptors.impl.EditorConfigStringDescriptor
+import org.editorconfig.language.schema.descriptors.impl.EditorConfigUnionDescriptor
+
+class KtlintEditorConfigOptionDescriptorProvider : EditorConfigOptionDescriptorProvider {
+    private lateinit var ktlintRuleIds: List<RuleId>
+    private lateinit var ktlintEditorConfigProperties: List<EditorConfigProperty<*>>
+
+    override fun initialize(project: Project) {
+        val ruleProviders = project.ruleProviders()
+        ktlintRuleIds = ruleProviders.map { it.ruleId }
+        ktlintEditorConfigProperties = ruleProviders.map { it.createNewRuleInstance().usesEditorConfigProperties }.flatten().distinct()
+    }
+
+    private fun Project.ruleProviders(): Set<RuleProvider> =
+        config()
+            .ruleSetProviders
+            .ruleProviders
+            .orEmpty()
+
+    override fun getOptionDescriptors(project: Project): List<EditorConfigOptionDescriptor> {
+        val editorConfigOptionDescriptors =
+            mutableListOf<EditorConfigOptionDescriptor>().apply {
+                addAll(enableOrDisableRulesetEditorConfigOptionDescriptor())
+                addAll(enableOrDisableRuleEditorConfigOptionDescriptors())
+                addAll(miscellaneousKtlintEditorConfigOptionDescriptor())
+            }
+        return editorConfigOptionDescriptors.toList()
+    }
+
+    private fun enableOrDisableRulesetEditorConfigOptionDescriptor(): List<EditorConfigOptionDescriptor> =
+        ktlintRuleIds
+            .map { it.ruleSetId }
+            .distinct()
+            .map { "ktlint_${it.value}" }
+            .map { ktlintRuleSetId ->
+                editorConfigOptionDescriptor(
+                    key = editorConfigConstantDescriptor(ktlintRuleSetId, "Enables or disables all rules in the ktlint ruleset"),
+                    value = enabledDisabledPropertyValueDescriptor,
+                )
+            }
+
+    private fun enableOrDisableRuleEditorConfigOptionDescriptors(): List<EditorConfigOptionDescriptor> =
+        ktlintRuleIds
+            .map { it.toKtlintRulePropertyName() }
+            .map { ktlintRuleId ->
+                editorConfigOptionDescriptor(
+                    key = editorConfigConstantDescriptor(ktlintRuleId, "Enables or disables the ktlint rule"),
+                    value = enabledDisabledPropertyValueDescriptor,
+                )
+            }
+
+    private fun RuleId.toKtlintRulePropertyName(): String = "ktlint_${value.replaceFirst(":", "_")}"
+
+    private fun miscellaneousKtlintEditorConfigOptionDescriptor(): List<EditorConfigOptionDescriptor> =
+        ktlintEditorConfigProperties
+            .map { ktlintEditorConfigProperty ->
+                editorConfigOptionDescriptor(
+                    key = ktlintEditorConfigProperty.toEditorConfigConstantDescriptorForKey(),
+                    value = ktlintEditorConfigProperty.toEditorConfigDescriptorForValue(),
+                )
+            }
+
+    private fun EditorConfigProperty<*>.toEditorConfigConstantDescriptorForKey(): EditorConfigConstantDescriptor =
+        EditorConfigConstantDescriptor(name, type.description, null)
+
+    private fun EditorConfigProperty<*>.toEditorConfigDescriptorForValue(): EditorConfigMutableDescriptor =
+        if (type is PropertyType.LowerCasingPropertyType && type.possibleValues.isNotEmpty()) {
+            EditorConfigUnionDescriptor(
+                children = type.possibleValues.map { editorConfigConstantDescriptor(it) },
+                documentation = null,
+                deprecation = null,
+            )
+        } else {
+            EditorConfigStringDescriptor(null, null, null)
+        }
+
+    override fun requiresFullSupport(): Boolean = true
+
+    private val enabledDisabledPropertyValueDescriptor =
+        EditorConfigUnionDescriptor(
+            children =
+                listOf(
+                    editorConfigConstantDescriptor("enabled"),
+                    editorConfigConstantDescriptor("disabled"),
+                ),
+            documentation = null,
+            deprecation = null,
+        )
+
+    private fun editorConfigOptionDescriptor(
+        key: EditorConfigDescriptor,
+        value: EditorConfigDescriptor,
+    ) = EditorConfigOptionDescriptor(key = key, value = value, documentation = null, deprecation = null)
+
+    private fun editorConfigConstantDescriptor(
+        text: String,
+        documentation: String? = null,
+    ): EditorConfigConstantDescriptor = EditorConfigConstantDescriptor(text, documentation, null)
+}

--- a/ktlint-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ktlint-plugin/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>org.jetbrains.kotlin</depends>
+    <depends>org.editorconfig.editorconfigjetbrains</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <externalAnnotator language="kotlin" implementationClass="com.nbadal.ktlint.KtlintAnnotator" id="KtlintAnnotator"/>
@@ -20,6 +21,10 @@
     <!-- https://kotlin.github.io/analysis-api/declaring-k2-compatibility.html -->
     <extensions defaultExtensionNs="org.jetbrains.kotlin">
         <supportsKotlinPluginMode supportsK2="true" />
+    </extensions>
+
+    <extensions defaultExtensionNs="editorconfig">
+        <optionDescriptorProvider implementation="com.nbadal.ktlint.KtlintEditorConfigOptionDescriptorProvider"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
* autocomplete on ktlint properties, and when applicable the allowed values
* shows a description on hovering ktlint properties
* works both for standard ktlint properties as well as for custom rulesets

Closes #300