### PR TITLE
Change platform type from IC to IU

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ pluginSinceBuild = 241
 pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformType = IC
+platformType = IU
 platformVersion = 2024.1.7
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/ktlint-plugin/build.gradle.kts
+++ b/ktlint-plugin/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
@@ -174,6 +176,12 @@ intellijPlatform {
     pluginVerification {
         ides {
             recommended()
+            select {
+                types = listOf(IntelliJPlatformType.IntellijIdea, IntelliJPlatformType.AndroidStudio)
+                channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
+                sinceBuild = providers.gradleProperty("pluginSinceBuild")
+                untilBuild = providers.gradleProperty("pluginUntilBuild")
+            }
         }
     }
 }

--- a/ktlint-plugin/build.gradle.kts
+++ b/ktlint-plugin/build.gradle.kts
@@ -177,7 +177,7 @@ intellijPlatform {
         ides {
             recommended()
             select {
-                types = listOf(IntelliJPlatformType.IntellijIdea, IntelliJPlatformType.AndroidStudio)
+                types = listOf(IntelliJPlatformType.IntellijIdea)
                 channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
                 sinceBuild = providers.gradleProperty("pluginSinceBuild")
                 untilBuild = providers.gradleProperty("pluginUntilBuild")


### PR DESCRIPTION
Change platform type as starting from Idea 2025.3 the IC build no longer exists