### PR TITLE
Limit the number of IDEA versions that are verified in GitHub build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,11 @@ pluginVersion = 0.30.0-beta-1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # When supporting too many versions, the pluginVerifier task in the build crashes because it runs out of disk space as
-# each supported version is download for verification
+# each supported version is download for verification. For that the verifyPluginSinceBuild should be set to the same or a later version. The
+# plugin can still be used with versions starting from pluginSinceBuild until verifyPluginSinceBuild, but they are not verified in the
+# GitHub build. Verification however still happens by Jetbrains, and can be looked-up via the marketplace.
 pluginSinceBuild = 241
+verifyPluginSinceBuild = 251
 pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension

--- a/ktlint-plugin/build.gradle.kts
+++ b/ktlint-plugin/build.gradle.kts
@@ -179,7 +179,11 @@ intellijPlatform {
             select {
                 types = listOf(IntelliJPlatformType.IntellijIdea)
                 channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
-                sinceBuild = providers.gradleProperty("pluginSinceBuild")
+                // When supporting too many versions, the pluginVerifier task in the build crashes because it runs out of disk space as
+                // each supported version is downloaded for verification. So in the GitHub build, we restrict the number of IDEA versions
+                // that are verified to a subset of the IDEA version in which the plugin can be used. Note that Jetbrains still performs a
+                // verification on all IDEA versions. Those results can be looked up via the plugin marketplace.
+                sinceBuild = providers.gradleProperty("verifyPluginSinceBuild")
                 untilBuild = providers.gradleProperty("pluginUntilBuild")
             }
         }


### PR DESCRIPTION
This is to prevent build failures due to lack of diskspace to verify all versions of the IDEA in which the plugin can be used.