### PR TITLE
Assign notification to different notification groups for better customizability by user

### DIFF
--- a/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/KtlintNotifier.kt
+++ b/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/KtlintNotifier.kt
@@ -1,56 +1,68 @@
 package com.nbadal.ktlint
 
 import com.intellij.notification.Notification
-import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.notification.NotificationType.ERROR
 import com.intellij.notification.NotificationType.INFORMATION
 import com.intellij.notification.NotificationType.WARNING
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
-import com.intellij.util.applyIf
 
 private val logger = KtlintLogger(KtlintProjectSettings::class.qualifiedName)
 
 object KtlintNotifier {
-    private const val KTLINT_NOTIFICATION_GROUP = "Ktlint Notifications"
+    // Notification groups should be used for related notifications. Note that a user is abled to disable notifications per group only.
+    // Notification groups are defined in file "plugin.xml". The title associated with the enum value should match with the title in the file "plugin.xml"
+    enum class KtlintNotificationGroup(
+        val title: String,
+    ) {
+        // Configuration messages are shown as sticky balloons by default as they should be ignored only explicitly by user
+        CONFIGURATION("Ktlint Configuration"),
+
+        // Rule exception messages are shown as sticky balloons by default as the user should report problems with rules to the maintainer
+        RULE("Ktlint Rule"),
+
+        // Default message are shown as normal balloons which disappear automatically. These should be used for less important messages.
+        DEFAULT("Ktlint Notifications"),
+    }
 
     fun notifyError(
+        notificationGroup: KtlintNotificationGroup,
         project: Project,
         title: String,
         message: String,
-        forceSettingsDialog: Boolean = false,
-    ) = notify(project, title, message, ERROR, forceSettingsDialog)
+        notificationCustomizer: Notification.() -> Notification = { this },
+    ) = notify(notificationGroup, project, title, message, ERROR, notificationCustomizer)
 
     fun notifyWarning(
+        notificationGroup: KtlintNotificationGroup,
         project: Project,
         title: String,
         message: String,
-        forceSettingsDialog: Boolean = false,
-    ) = notify(project, title, message, WARNING, forceSettingsDialog)
+        notificationCustomizer: (Notification.() -> Notification) = { this },
+    ) = notify(notificationGroup, project, title, message, WARNING, notificationCustomizer)
 
     fun notifyInformation(
+        notificationGroup: KtlintNotificationGroup,
         project: Project,
         title: String,
         message: String,
-        forceSettingsDialog: Boolean = false,
-    ) = notify(project, title, message, INFORMATION, forceSettingsDialog)
+        notificationCustomizer: (Notification.() -> Notification) = { this },
+    ) = notify(notificationGroup, project, title, message, INFORMATION, notificationCustomizer)
 
     private fun notify(
+        notificationGroup: KtlintNotificationGroup,
         project: Project,
         title: String,
         message: String,
         notificationType: NotificationType,
-        forceSettingsDialog: Boolean = false,
+        notificationCustomizer: (Notification.() -> Notification),
     ) = NotificationGroupManager
         .getInstance()
-        .getNotificationGroup(KTLINT_NOTIFICATION_GROUP)
+        .getNotificationGroup(notificationGroup.title)
         .createNotification(title, message, notificationType)
-        .applyIf(forceSettingsDialog || project.isEnabled(KtlintFeature.SHOW_INTENTION_SETTINGS_DIALOG)) {
-            addAction(OpenSettingsAction(project))
-        }.notify(project)
+        .apply { notificationCustomizer() }
+        .notify(project)
         .also {
             when (notificationType) {
                 ERROR -> logger.error { message }
@@ -58,15 +70,4 @@ object KtlintNotifier {
                 else -> logger.debug { message }
             }
         }
-
-    private class OpenSettingsAction(
-        val project: Project,
-    ) : NotificationAction("Open ktlint settings...") {
-        override fun actionPerformed(
-            e: AnActionEvent,
-            notification: Notification,
-        ) {
-            ShowSettingsUtil.getInstance().showSettingsDialog(project, KtlintConfig::class.java)
-        }
-    }
 }

--- a/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/KtlintPluginsPropertiesReader.kt
+++ b/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/KtlintPluginsPropertiesReader.kt
@@ -1,7 +1,11 @@
 package com.nbadal.ktlint
 
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.nbadal.ktlint.KtlintNotifier.KtlintNotificationGroup.CONFIGURATION
 import com.pinterest.ktlint.ruleset.standard.KtlintRulesetVersion
 import java.nio.file.Path
 
@@ -12,15 +16,21 @@ private val logger = KtlintLogger("com.nbdal.ktlint.KtlintPluginsPropertiesReade
 
 class KtlintPluginsPropertiesReader {
     private var properties: Map<String, String> = emptyMap()
-    private var projectBasePath: String? = null
+    private var project: Project? = null
+    private var projectBasepath: String? = null
     private var readFromKtlintPluginPropertiesFile = false
+    private var showErrorOnUnsupportedKtlintVersion = true
 
-    fun configure(projectBasePath: String?) {
-        this.projectBasePath = projectBasePath
-        properties =
-            ktlintPluginsPropertiesVirtualFile(projectBasePath)
-                ?.readProperties()
-                ?: emptyMap()
+    fun configure(project: Project?) {
+        if (this.project != project || this.project?.basePath != projectBasepath) {
+            this.project = project
+            projectBasepath = project?.basePath
+            showErrorOnUnsupportedKtlintVersion = true
+            properties =
+                ktlintPluginsPropertiesVirtualFile(project?.basePath)
+                    ?.readProperties()
+                    ?: emptyMap()
+        }
     }
 
     private fun ktlintPluginsPropertiesVirtualFile(projectBasePath: String?) =
@@ -51,7 +61,7 @@ class KtlintPluginsPropertiesReader {
 
     fun ktlintRulesetVersion(): KtlintRulesetVersion? {
         if (!readFromKtlintPluginPropertiesFile) {
-            logger.debug { "File '$KTLINT_PLUGINS_PROPERTIES_FILE_NAME' not found in $projectBasePath" }
+            logger.debug { "File '$KTLINT_PLUGINS_PROPERTIES_FILE_NAME' not found in ${project?.basePath}" }
             return null
         }
 
@@ -59,7 +69,7 @@ class KtlintPluginsPropertiesReader {
         return if (ktlintVersionLabel.isNullOrBlank()) {
             logger.debug {
                 "No value found for property '$KTLINT_PLUGINS_VERSION_PROPERTY' in file '$KTLINT_PLUGINS_PROPERTIES_FILE_NAME' " +
-                    "in $projectBasePath"
+                    "in ${project?.basePath}"
             }
             null
         } else {
@@ -75,6 +85,28 @@ class KtlintPluginsPropertiesReader {
                     logger.debug {
                         "Ktlint version '$ktlintVersionLabel' defined in property '$KTLINT_PLUGINS_VERSION_PROPERTY' in file " +
                             "'$KTLINT_PLUGINS_PROPERTIES_FILE_NAME' is not supported by this version of the ktlint-intellij-plugin."
+                    }
+                    if (showErrorOnUnsupportedKtlintVersion) {
+                        // Prevent the error from being shown too many times
+                        showErrorOnUnsupportedKtlintVersion = false
+
+                        val ktlintPluginVersion =
+                            PluginManager
+                                .getInstance()
+                                .findEnabledPlugin(PluginId.findId("com.nbadal.ktlint")!!)
+                                ?.version
+
+                        KtlintNotifier
+                            .notifyError(
+                                notificationGroup = CONFIGURATION,
+                                project = project!!,
+                                title = "Unsupported Ktlint version",
+                                message =
+                                    """
+                                    Ktlint version <strong>$ktlintVersionLabel</strong> is not supported by current version 
+                                    (<strong>$ktlintPluginVersion</strong>) of Ktlint Intelli Plugin.
+                                    """.trimIndent(),
+                            )
                     }
                 }
         }

--- a/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
+++ b/ktlint-plugin/src/main/kotlin/com/nbadal/ktlint/actions/FormatAction.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiManager
 import com.nbadal.ktlint.KtlintFeature.SHOW_MENU_OPTION_FORMAT_WITH_KTLINT
 import com.nbadal.ktlint.KtlintFileAutocorrectHandler
 import com.nbadal.ktlint.KtlintMode.DISTRACT_FREE
+import com.nbadal.ktlint.KtlintNotifier.KtlintNotificationGroup.DEFAULT
 import com.nbadal.ktlint.KtlintNotifier.notifyInformation
 import com.nbadal.ktlint.KtlintNotifier.notifyWarning
 import com.nbadal.ktlint.KtlintRuleEngineWrapper
@@ -57,6 +58,7 @@ class FormatAction : AnAction() {
         when (ktlintFormatContentIterator.status) {
             SUCCESS -> {
                 notifyInformation(
+                    notificationGroup = DEFAULT,
                     project = project,
                     title = "Format with Ktlint",
                     message = message,
@@ -65,6 +67,7 @@ class FormatAction : AnAction() {
 
             FILE_RELATED_ERROR -> {
                 notifyWarning(
+                    notificationGroup = DEFAULT,
                     project = project,
                     title = "Format with Ktlint",
                     message = message,

--- a/ktlint-plugin/src/main/resources/META-INF/plugin.xml
+++ b/ktlint-plugin/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,10 @@
         <postFormatProcessor implementation="com.nbadal.ktlint.KtlintPostFormatProcessor" />
         <projectConfigurable displayName="KtLint" groupId="tools" id="preferences.ktlint-plugin"
                              instance="com.nbadal.ktlint.KtlintConfig"/>
+        <notificationGroup id="Ktlint Baseline" displayType="STICKY_BALLOON"/>
+        <notificationGroup id="Ktlint Configuration" displayType="STICKY_BALLOON"/>
         <notificationGroup id="Ktlint Notifications" displayType="BALLOON"/>
+        <notificationGroup id="Ktlint Rule Exception" displayType="STICKY_BALLOON"/>
         <actionOnSaveInfoProvider implementation="com.nbadal.ktlint.KtlintActionOnSaveInfoProvider"
                                   order="after FormatOnSaveInfoProvider"/>
         <actionOnSave implementation="com.nbadal.ktlint.KtlintActionOnSave" order="after FormatOnSaveAction"/>


### PR DESCRIPTION
Assign notification to different notification groups for better customizability by user

Configuration and rule notification are now displayed in sticky balloons by default. When switching projects, the notification about an invalid ktlint version configured in the "ktlint-version.properties" file is displayed only once.

Remaining notification are displayed in normal balloons which disappear automatically.

KtlintParseExceptions are suppressed. Those exceptions happen a lot when code is saved while it can not yet be compiled successfully.