### PR TITLE
Migrate to Shadow 9

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     gradlePluginPortal()
     mavenCentral()
 }

--- a/build-logic/src/main/kotlin/ktlint-ruleset.gradle.kts
+++ b/build-logic/src/main/kotlin/ktlint-ruleset.gradle.kts
@@ -62,6 +62,9 @@ afterEvaluate {
             "com.pinterest.ktlint.ruleset.standard.$relocateSuffix",
         )
 
+        @Suppress("DEPRECATION") // Will be removed in Shadow 10.
+        enableKotlinModuleRemapping.set(false)
+
         minimize {
             exclude(dependency("com.pinterest.ktlint:ktlint-ruleset-standard:$ktlintVersion"))
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kover = "0.9.9"
 ktlint = "1.8.0"
 mockk = "1.14.11"
 qodana = "2026.1.3"
-shadow = "8.3.11"
+shadow = "9.6.1"
 slf4j="2.0.18"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kover = "0.9.9"
 ktlint = "1.8.0"
 mockk = "1.14.11"
 qodana = "2026.1.3"
-shadow = "9.6.1"
+shadow = "9.7.0-SNAPSHOT"
 slf4j="2.0.18"
 
 [libraries]

--- a/ktlint-lib/build.gradle.kts
+++ b/ktlint-lib/build.gradle.kts
@@ -117,6 +117,9 @@ tasks {
         relocate("org.jetbrains.concurrency", "shadow.org.jetbrains.concurrency")
         relocate("org.jetbrains.kotlin", "shadow.org.jetbrains.kotlin")
 
+        @Suppress("DEPRECATION") // Will be removed in Shadow 10.
+        enableKotlinModuleRemapping.set(false)
+
         // Ktlint-lib itself may not be minimized as this would result in exceptions when loading custom rulesets as the RulesetProviderV3
         // cannot be found
     }

--- a/ktlint-plugin/src/test/kotlin/com/nbadal/ktlint/KtlintTest.kt
+++ b/ktlint-plugin/src/test/kotlin/com/nbadal/ktlint/KtlintTest.kt
@@ -1,13 +1,20 @@
 package com.nbadal.ktlint
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-// With update of the "platformVersion" to "2025.1.x" all tests broke due to a failure in setting up the TestLogger class. With this upgrade
-// the internal working of the test engine in the platform has changed considerably. As testing was still in a very early phase there is not
-// too much lost by removing the tests.
 class KtlintTest {
     @Test
-    fun `Dummy test`() {
-        // At least one successful test is needed for the GitHub build pipeline to succeed.
+    fun `test Case sensitive relocated fastutil classes can be loaded correctly`() {
+        val classLoader = KtlintTest::class.java.classLoader
+
+        val lowerClass = classLoader.loadClass("shadow.org.jetbrains.kotlin.it.unimi.dsi.fastutil.ints.o")
+        val upperClass = classLoader.loadClass("shadow.org.jetbrains.kotlin.it.unimi.dsi.fastutil.ints.O")
+        val annotationRuleClass = Class.forName("com.pinterest.ktlint.ruleset.standard.V1_8_0.rules.AnnotationRule")
+
+        assertThat(lowerClass.name).isEqualTo("shadow.org.jetbrains.kotlin.it.unimi.dsi.fastutil.ints.o")
+        assertThat(upperClass.name).isEqualTo("shadow.org.jetbrains.kotlin.it.unimi.dsi.fastutil.ints.O")
+        assertThat(annotationRuleClass).isNotNull()
     }
 }
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,9 @@
 pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+    }
     includeBuild("build-logic")
 }
 


### PR DESCRIPTION
```
OLD: ktlint-lib-all-shadow-8.3.11.jar (73.15 MiB)
NEW: ktlint-lib-all-shadow-9.7.0.jar  (72.90 MiB)

       │             compressed              │            uncompressed             
       ├───────────┬───────────┬─────────────┼────────────┬────────────┬───────────
 JAR   │ old       │ new       │ diff        │ old        │ new        │ diff      
───────┼───────────┼───────────┼─────────────┼────────────┼────────────┼───────────
 class │ 72.02 MiB │ 71.77 MiB │ -253.92 KiB │ 184.71 MiB │ 182.69 MiB │ -2.02 MiB 
 other │  1.13 MiB │  1.13 MiB │       +21 B │   2.42 MiB │   2.42 MiB │     +21 B 
───────┼───────────┼───────────┼─────────────┼────────────┼────────────┼───────────
 total │ 73.15 MiB │  72.90 MiB│  -253.9 KiB │ 187.13 MiB │ 185.11 MiB │ -2.02 MiB 

 CLASSES │ old    │ new    │ diff       
─────────┼────────┼────────┼────────────
 classes │  34303 │  34302 │ -1 (+0 -1) 
 methods │ 305681 │ 305681 │  0 (+0 -0) 
  fields │  77449 │  77449 │  0 (+0 -0)
```